### PR TITLE
Specify Open JDK 17 in JitPack config

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-- openjdk11
+- openjdk17

--- a/swiper/build.gradle.kts
+++ b/swiper/build.gradle.kts
@@ -45,7 +45,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 groupId = "moe.tlaster"
                 artifactId = "swiper"
-                version = "0.7.0"
+                version = "0.7.1"
 
                 from(components["release"])
             }


### PR DESCRIPTION
Android 14 requires OpenJDK 17 so the JitPack build failed

- https://jitpack.io/com/github/Tlaster/Swiper/0.7.0/build.log

I updated the yml file and it looks like it works now:

- https://jitpack.io/com/github/jocmp/Swiper/0.7.1/build.log

It's updated the version to 0.7.1 to avoid overlapping tags.